### PR TITLE
Use cachepot as rustc wrapper by default

### DIFF
--- a/rust/1.56.1/Dockerfile
+++ b/rust/1.56.1/Dockerfile
@@ -52,6 +52,7 @@ RUN set -e \
 RUN set -e \
 	&& rustup component add llvm-tools-preview rustfmt clippy \
 	&& cargo install --git https://github.com/paritytech/cachepot
+ENV RUSTC_WRAPPER=cachepot
 
 # Python
 ENV PYTHON_VERSION 3.9.2

--- a/rust/1.58.0/Dockerfile
+++ b/rust/1.58.0/Dockerfile
@@ -52,6 +52,7 @@ RUN set -e \
 RUN set -e \
 	&& rustup component add llvm-tools-preview rustfmt clippy \
 	&& cargo install --git https://github.com/paritytech/cachepot
+ENV RUSTC_WRAPPER=cachepot
 
 # Python
 ENV PYTHON_VERSION 3.9.2


### PR DESCRIPTION
If we ever change the image to something different, we might have cachepot installed to a different location. To avoid changing it manually everywhere, rather set it here.
The users who will want to opt out from caching, might set the wrapper env var to an empty string.