### PR TITLE
Update rust 1.58.0 -> 1.58.1

### DIFF
--- a/.github/workflows/rust.yaml
+++ b/.github/workflows/rust.yaml
@@ -29,10 +29,10 @@ jobs:
           tags: zimg/rust:1.56.1,zimg/rust:1.56,zimg/rust:stable
 
       -
-        name: rust-1.58.0
+        name: rust-1.58.1
         uses: docker/build-push-action@v2
         with:
-          context: rust/1.58.0
+          context: rust/1.58.1
           pull: true
           push: true
-          tags: zimg/rust:1.58.0,zimg/rust:1.58,zimg/rust:edge
+          tags: zimg/rust:1.58.1,zimg/rust:1.58,zimg/rust:edge

--- a/rust/1.58.1/Dockerfile
+++ b/rust/1.58.1/Dockerfile
@@ -1,4 +1,4 @@
-ARG RUST_VERSION=1.58.0
+ARG RUST_VERSION=1.58.1
 
 FROM cimg/rust:${RUST_VERSION}
 
@@ -51,7 +51,8 @@ RUN set -e \
 # Rust deps
 RUN set -e \
 	&& rustup component add llvm-tools-preview rustfmt clippy \
-	&& cargo install --git https://github.com/paritytech/cachepot
+	&& cargo install --git https://github.com/paritytech/cachepot \
+	&& cargo install rustfilt
 
 # Python
 ENV PYTHON_VERSION 3.9.2


### PR DESCRIPTION
This release contains security fixes, which is why I yanked the whole recipe for 1.58.0. Apart from that I added https://github.com/luser/rustfilt to the image, which should make coverage reports more readable.