### PR TITLE
Remove 'tk-dev' from the image.

### DIFF
--- a/rust/Dockerfile
+++ b/rust/Dockerfile
@@ -42,7 +42,6 @@ RUN set -e \
         parallel \
         pkg-config \
         postgresql-client \
-        tk-dev \
         wget \
         xz-utils \
         zlib1g-dev \


### PR DESCRIPTION
It's not needed for anything.

To test this, I
1. Created an image with this change
2. Uploaded it to docker hub, as `hlinnaka/zimg-test:0.0.1`.
3. Replaced all instances of `zimg/rust:1.58` with `hlinnaka/zimg-test:0.0.1` in the neon repository
4. Pushed that as a `docker-zimg-test` branch to the 'neon` repository

The CI passed with that: https://app.circleci.com/pipelines/github/neondatabase/neon/5821/workflows/5a702d45-e1e4-45a9-a866-82deb174f932
